### PR TITLE
Improvements to the smart contract API README files

### DIFF
--- a/docs/app-development/random-beacon/README.md
+++ b/docs/app-development/random-beacon/README.md
@@ -1,3 +1,11 @@
 # Random Beacon
 
-To get familiarized with Random Bitcoin contracts API, go [here](random-beacon-api/generated-docs/index.md).
+
+Threshold Network Random Beacon contracts source code is available in the
+[`keep-network/keep-core`](https://github.com/keep-network/keep-core/tree/main/solidity/random-beacon)
+GitHub repository.
+
+The smart contract API documentation is generated based on the NatSpec format
+documentation in the smart contract source code.
+
+The Random Bitcoin contracts API docs are available [here](random-beacon-api/generated-docs/index.md).

--- a/docs/app-development/random-beacon/random-beacon-api/README.md
+++ b/docs/app-development/random-beacon/random-beacon-api/README.md
@@ -1,42 +1,24 @@
 # Random Beacon API
 
-You can learn about APIs of contracts related to the Random Beacon under the
-following links:
+You can learn about APIs of Random Beacon smart contracts under the following
+links:
 
-[AltBn128](./generated-docs/libraries/AltBn128.md)
-
-[BeaconAuthorization](./generated-docs/libraries/BeaconAuthorization.md)
-
-[BeaconDkg](./generated-docs/libraries/BeaconDkg.md)
-
-[BeaconDkgValidator](./generated-docs/BeaconDkgValidator.md)
-
-[BeaconInactivity](./generated-docs/libraries/BeaconInactivity.md)
-
-[BLS](./generated-docs/libraries/BLS.md)
-
-[BytesLib](./generated-docs/libraries/BytesLib.md)
-
-[Callback](./generated-docs/libraries/Callback.md)
-
-[Governable](./generated-docs/Governable.md)
-
-[Groups](./generated-docs/libraries/Groups.md)
-
-[IRandomBeacon](./generated-docs/api/IRandomBeacon.md)
-
-[IRandomBeaconConsumer](./generated-docs/api/IRandomBeaconConsumer.md)
-
-[ModUtils](./generated-docs/libraries/ModUtils.md)
-
-[RandomBeacon](./generated-docs/RandomBeacon.md)
-
-[RandomBeaconChaosnet](./generated-docs/RandomBeaconChaosnet.md)
-
-[RandomBeaconGovernance](./generated-docs/RandomBeaconGovernance.md)
-
-[Reimbursable](./generated-docs/Reimbursable.md)
-
-[ReimbursementPool](./generated-docs/ReimbursementPool.md)
-
-[Relay](./generated-docs/libraries/Relay.md)
+* [AltBn128](./generated-docs/libraries/AltBn128.md)
+* [BeaconAuthorization](./generated-docs/libraries/BeaconAuthorization.md)
+* [BeaconDkg](./generated-docs/libraries/BeaconDkg.md)
+* [BeaconDkgValidator](./generated-docs/BeaconDkgValidator.md)
+* [BeaconInactivity](./generated-docs/libraries/BeaconInactivity.md)
+* [BLS](./generated-docs/libraries/BLS.md)
+* [BytesLib](./generated-docs/libraries/BytesLib.md)
+* [Callback](./generated-docs/libraries/Callback.md)
+* [Governable](./generated-docs/Governable.md)
+* [Groups](./generated-docs/libraries/Groups.md)
+* [IRandomBeacon](./generated-docs/api/IRandomBeacon.md)
+* [IRandomBeaconConsumer](./generated-docs/api/IRandomBeaconConsumer.md)
+* [ModUtils](./generated-docs/libraries/ModUtils.md)
+* [RandomBeacon](./generated-docs/RandomBeacon.md)
+* [RandomBeaconChaosnet](./generated-docs/RandomBeaconChaosnet.md)
+* [RandomBeaconGovernance](./generated-docs/RandomBeaconGovernance.md)
+* [Reimbursable](./generated-docs/Reimbursable.md)
+* [ReimbursementPool](./generated-docs/ReimbursementPool.md)
+* [Relay](./generated-docs/libraries/Relay.md)

--- a/docs/app-development/staking-contract-and-dao/README.md
+++ b/docs/app-development/staking-contract-and-dao/README.md
@@ -1,3 +1,10 @@
 # Staking Contract and DAO
 
-To get familiarized with API of contracts related to staking and DAO, go [here](staking-contract-and-dao-api/generated-docs/index.md).
+Threshold Network staking and DAO contracts source code is available in the
+[`threshold-network/solidity-contracts`](https://github.com/threshold-network/solidity-contracts)
+GitHub repository.
+
+The smart contract API documentation is generated based on the NatSpec format
+documentation in the smart contract source code.
+
+The staking and DAO contracts API docs are available [here](staking-contract-and-dao-api/generated-docs/index.md).

--- a/docs/app-development/staking-contract-and-dao/staking-contract-and-dao-api/README.md
+++ b/docs/app-development/staking-contract-and-dao/staking-contract-and-dao-api/README.md
@@ -1,40 +1,23 @@
 # Staking Contract and DAO API
 
-You can learn about APIs of contracts related to staking and DAO under the
-following links:
+You can learn about APIs of staking and DAO smart contracts under the following
+links:
 
-[BaseTokenholderGovernor](./generated-docs/governance/BaseTokenholderGovernor.md)
-
-[Checkpoints](./generated-docs/governance/Checkpoints.md)
-
-[GovernorParameters](./generated-docs/governance/GovernorParameters.md)
-
-[IApplication](./generated-docs/staking/IApplication.md)
-
-[ILegacyTokenStaking](./generated-docs/staking/ILegacyTokenStaking.md)
-
-[IStaking](./generated-docs/staking/IStaking.md)
-
-[IVotesHistory](./generated-docs/governance/IVotesHistory.md)
-
-[KeepStake](./generated-docs/staking/KeepStake.md)
-
-[PercentUtils](./generated-docs/utils/PercentUtils.md)
-
-[ProxyAdminWithDeputy](./generated-docs/governance/ProxyAdminWithDeputy.md)
-
-[SafeTUpgradeable](./generated-docs/utils/SafeTUpgradeable.md)
-
-[StakerGovernor](./generated-docs/governance/StakerGovernor.md)
-
-[StakerGovernorVotes](./generated-docs/governance/StakerGovernorVotes.md)
-
-[T](./generated-docs/token/T.md)
-
-[TokenholderGovernor](./generated-docs/governance/TokenholderGovernor.md)
-
-[TokenholderGovernorVotes](./generated-docs/governance/TokenholderGovernorVotes.md)
-
-[TokenStaking](./generated-docs/staking/TokenStaking.md)
-
-[VendingMachine](./generated-docs/vendingVendingMachine.md)
+* [BaseTokenholderGovernor](./generated-docs/governance/BaseTokenholderGovernor.md)
+* [Checkpoints](./generated-docs/governance/Checkpoints.md)
+* [GovernorParameters](./generated-docs/governance/GovernorParameters.md)
+* [IApplication](./generated-docs/staking/IApplication.md)
+* [ILegacyTokenStaking](./generated-docs/staking/ILegacyTokenStaking.md)
+* [IStaking](./generated-docs/staking/IStaking.md)
+* [IVotesHistory](./generated-docs/governance/IVotesHistory.md)
+* [KeepStake](./generated-docs/staking/KeepStake.md)
+* [PercentUtils](./generated-docs/utils/PercentUtils.md)
+* [ProxyAdminWithDeputy](./generated-docs/governance/ProxyAdminWithDeputy.md)
+* [SafeTUpgradeable](./generated-docs/utils/SafeTUpgradeable.md)
+* [StakerGovernor](./generated-docs/governance/StakerGovernor.md)
+* [StakerGovernorVotes](./generated-docs/governance/StakerGovernorVotes.md)
+* [T](./generated-docs/token/T.md)
+* [TokenholderGovernor](./generated-docs/governance/TokenholderGovernor.md)
+* [TokenholderGovernorVotes](./generated-docs/governance/TokenholderGovernorVotes.md)
+* [TokenStaking](./generated-docs/staking/TokenStaking.md)
+* [VendingMachine](./generated-docs/vendingVendingMachine.md)

--- a/docs/app-development/tbtc-v2/README.md
+++ b/docs/app-development/tbtc-v2/README.md
@@ -1,5 +1,16 @@
 # tBTC
 
-To get familiarized with ECDSA contracts API, go [here](ecdsa-api/generated-docs/index.md).
+Threshold Network ECDSA contracts source code is available in the 
+[`keep-network/keep-core`](https://github.com/keep-network/keep-core/tree/main/solidity/ecdsa)
+GitHub repository.
 
-To get familiarized with Bridge contracts API, go [here](tbtc-v2-api/generated-docs/index.md).
+Threshold Network tBTC Bridge contracts source code is available in the
+[`keep-network/tbtc-v2`](https://github.com/keep-network/tbtc-v2/tree/main/solidity)
+GitHub repository.
+
+The smart contract API documentation is generated based on the NatSpec format
+documentation in the smart contract source code.
+
+The ECDSA contracts API docs are available [here](ecdsa-api/generated-docs/index.md).
+
+The tBTC Bridge contracts API docs ara available [here](tbtc-v2-api/generated-docs/index.md).

--- a/docs/app-development/tbtc-v2/ecdsa-api/README.md
+++ b/docs/app-development/tbtc-v2/ecdsa-api/README.md
@@ -1,22 +1,13 @@
 # ECDSA API
 
-You can learn about APIs of contracts related to ECDSA under the following
-links:
+You can learn about APIs of ECDSA smart contracts under the following links:
 
-[EcdsaAuthorization](./generated-docs/libraries/EcdsaAuthorization.md)
-
-[EcdsaDkg](./generated-docs/libraries/EcdsaDkg.md)
-
-[EcdsaDkgValidator](./generated-docs/EcdsaDkgValidator.md)
-
-[EcdsaInactivity](./generated-docs/libraries/EcdsaInactivity.md)
-
-[IWalletOwner](./generated-docs/api/IWalletOwner.md)
-
-[IWalletRegistry](./generated-docs/api/IWalletRegistry.md)
-
-[WalletRegistry](./generated-docs/WalletRegistry.md)
-
-[WalletRegistryGovernance](./generated-docs/WalletRegistryGovernance.md)
-
-[Wallets](./generated-docs/libraries/Wallets.md)
+* [EcdsaAuthorization](./generated-docs/libraries/EcdsaAuthorization.md)
+* [EcdsaDkg](./generated-docs/libraries/EcdsaDkg.md)
+* [EcdsaDkgValidator](./generated-docs/EcdsaDkgValidator.md)
+* [EcdsaInactivity](./generated-docs/libraries/EcdsaInactivity.md)
+* [IWalletOwner](./generated-docs/api/IWalletOwner.md)
+* [IWalletRegistry](./generated-docs/api/IWalletRegistry.md)
+* [WalletRegistry](./generated-docs/WalletRegistry.md)
+* [WalletRegistryGovernance](./generated-docs/WalletRegistryGovernance.md)
+* [Wallets](./generated-docs/libraries/Wallets.md)

--- a/docs/app-development/tbtc-v2/tbtc-v2-api/README.md
+++ b/docs/app-development/tbtc-v2/tbtc-v2-api/README.md
@@ -1,66 +1,36 @@
 # Bridge API
 
-You can learn about APIs of contracts related to the Bridge under the following
+You can learn about APIs of tBTC Bridge smart contracts under the following
 links:
 
-[Bank](./generated-docs/bank/Bank.md)
-
-[BitcoinTx](./generated-docs/bridge/BitcoinTx.md)
-
-[Bridge](./generated-docs/bridge/Bridge.md)
-
-[BridgeGovernance](./generated-docs/bridge/BridgeGovernance.md)
-
-[BridgeGovernanceParameters](./generated-docs/bridge/BridgeGovernanceParameters.md)
-
-[BridgeState](./generated-docs/bridge/BridgeState.md)
-
-[Deposit](./generated-docs/bridge/Deposit.md)
-
-[DepositSweep](./generated-docs/bridge/DepositSweep.md)
-
-[DonationVault](./generated-docs/vault/DonationVault.md)
-
-[EcdsaLib](./generated-docs/bridge/EcdsaLib.md)
-
-[Fraud](./generated-docs/bridge/Fraud.md)
-
-[GovernanceUtils](./generated-docs/GovernanceUtils.md)
-
-[Heartbeat](./generated-docs/bridge/Heartbeat.md)
-
-[IReceiveBalanceApproval](./generated-docs/bank/IReceiveBalanceApproval.md)
-
-[IRelay](./generated-docs/bridge/IRelay.md)
-
-[IVault](./generated-docs/vault/IVault.md)
-
-[L2TBTC](./generated-docs/l2/L2TBTC.md)
-
-[L2WormholeGateway](./generated-docs/l2/L2WormholeGateway.md)
-
-[LightRelay](./generated-docs/relay/LightRelay.md)
-
-[LightRelayMaintainerProxy](./generated-docs/relay/LightRelayMaintainerProxy.md)
-
-[MaintainerProxy](./generated-docs/maintainer/MaintainerProxy.md)
-
-[MovingFunds](./generated-docs/bridge/MovingFunds.md)
-
-[Redemption](./generated-docs/bridge/Redemption.md)
-
-[TBTC](./generated-docs/token/TBTC.md)
-
-[TBTCOptimisticMinting](./generated-docs/vault/TBTCOptimisticMinting.md)
-
-[TBTCVault](./generated-docs/vault/TBTCVault.md)
-
-[VendingMachine](./generated-docs/bridge/VendingMachine.md)
-
-[VendingMachineV2](./generated-docs/bridge/VendingMachineV2.md)
-
-[VendingMachineV3](./generated-docs/bridge/VendingMachineV3.md)
-
-[WalletCoordinator](./generated-docs/bridge/WalletCoordinator.md)
-
-[Wallets](./generated-docs/bridge/Wallets.md)
+* [Bank](./generated-docs/bank/Bank.md)
+* [BitcoinTx](./generated-docs/bridge/BitcoinTx.md)
+* [Bridge](./generated-docs/bridge/Bridge.md)
+* [BridgeGovernance](./generated-docs/bridge/BridgeGovernance.md)
+* [BridgeGovernanceParameters](./generated-docs/bridge/BridgeGovernanceParameters.md)
+* [BridgeState](./generated-docs/bridge/BridgeState.md)
+* [Deposit](./generated-docs/bridge/Deposit.md)
+* [DepositSweep](./generated-docs/bridge/DepositSweep.md)
+* [DonationVault](./generated-docs/vault/DonationVault.md)
+* [EcdsaLib](./generated-docs/bridge/EcdsaLib.md)
+* [Fraud](./generated-docs/bridge/Fraud.md)
+* [GovernanceUtils](./generated-docs/GovernanceUtils.md)
+* [Heartbeat](./generated-docs/bridge/Heartbeat.md)
+* [IReceiveBalanceApproval](./generated-docs/bank/IReceiveBalanceApproval.md)
+* [IRelay](./generated-docs/bridge/IRelay.md)
+* [IVault](./generated-docs/vault/IVault.md)
+* [L2TBTC](./generated-docs/l2/L2TBTC.md)
+* [L2WormholeGateway](./generated-docs/l2/L2WormholeGateway.md)
+* [LightRelay](./generated-docs/relay/LightRelay.md)
+* [LightRelayMaintainerProxy](./generated-docs/relay/LightRelayMaintainerProxy.md)
+* [MaintainerProxy](./generated-docs/maintainer/MaintainerProxy.md)
+* [MovingFunds](./generated-docs/bridge/MovingFunds.md)
+* [Redemption](./generated-docs/bridge/Redemption.md)
+* [TBTC](./generated-docs/token/TBTC.md)
+* [TBTCOptimisticMinting](./generated-docs/vault/TBTCOptimisticMinting.md)
+* [TBTCVault](./generated-docs/vault/TBTCVault.md)
+* [VendingMachine](./generated-docs/bridge/VendingMachine.md)
+* [VendingMachineV2](./generated-docs/bridge/VendingMachineV2.md)
+* [VendingMachineV3](./generated-docs/bridge/VendingMachineV3.md)
+* [WalletCoordinator](./generated-docs/bridge/WalletCoordinator.md)
+* [Wallets](./generated-docs/bridge/Wallets.md)


### PR DESCRIPTION
Mentioned where the code for the given module is located and that the documentation is generated based on the NatSpec docs in the code.

Made the list of smart contracts for the given module a real list.